### PR TITLE
Add outgoing queue metrics for polymur, polymur-gateway

### DIFF
--- a/cmd/polymur/main.go
+++ b/cmd/polymur/main.go
@@ -38,14 +38,15 @@ import (
 
 var (
 	options struct {
-		addr         string
-		apiAddr      string
-		statAddr     string
-		queuecap     int
-		console      bool
-		destinations string
-		metricsFlush int
-		distribution string
+		addr             string
+		apiAddr          string
+		statAddr         string
+		incomingQueuecap int
+		outgoingQueuecap int
+		console          bool
+		destinations     string
+		metricsFlush     int
+		distribution     string
 	}
 
 	sig_chan = make(chan os.Signal)
@@ -55,7 +56,8 @@ func init() {
 	flag.StringVar(&options.addr, "listen-addr", "0.0.0.0:2003", "Polymur listen address")
 	flag.StringVar(&options.apiAddr, "api-addr", "localhost:2030", "API listen address")
 	flag.StringVar(&options.statAddr, "stat-addr", "localhost:2020", "runstats listen address")
-	flag.IntVar(&options.queuecap, "queue-cap", 4096, "In-flight message queue capacity per destination")
+	flag.IntVar(&options.outgoingQueuecap, "outgoing-queue-cap", 4096, "In-flight message queue capacity per destination")
+	flag.IntVar(&options.incomingQueuecap, "incoming-queue-cap", 32768, "In-flight incoming message queue capacity")
 	flag.BoolVar(&options.console, "console-out", false, "Dump output to console")
 	flag.StringVar(&options.destinations, "destinations", "", "Comma-delimited list of ip:port destinations")
 	flag.IntVar(&options.metricsFlush, "metrics-flush", 0, "Graphite flush interval for runtime metrics (0 is disabled)")
@@ -75,7 +77,7 @@ func main() {
 	log.Println("::: Polymur :::")
 	ready := make(chan bool, 1)
 
-	incomingQueue := make(chan []*string, 32768)
+	incomingQueue := make(chan []*string, options.incomingQueuecap)
 
 	pool := pool.NewPool()
 
@@ -90,7 +92,7 @@ func main() {
 				Destinations:  options.destinations,
 				Distribution:  options.distribution,
 				IncomingQueue: incomingQueue,
-				QueueCap:      options.queuecap,
+				QueueCap:      options.outgoingQueuecap,
 			},
 			ready)
 	}
@@ -115,7 +117,7 @@ func main() {
 
 	// Polymur stats writer.
 	if options.metricsFlush > 0 {
-		go runstats.WriteGraphite(incomingQueue, options.metricsFlush, sentCntr)
+		go runstats.WriteGraphiteWithBackendMetrics(pool, incomingQueue, options.incomingQueuecap, options.metricsFlush, sentCntr)
 	}
 
 	// Runtime stats listener.


### PR DESCRIPTION
Add outgoing queue metrics for polymur, polymur-gateway  
- outgoing queue size by destination and limit
- incoming queue size and limit

Make the incoming queue cap a flag in polymur, polymur-gateway